### PR TITLE
fix: Cred rotation 

### DIFF
--- a/internal/credential/attributes.go
+++ b/internal/credential/attributes.go
@@ -122,8 +122,6 @@ func GetCredentialsConfig(secrets *structpb.Struct, attrs *CredentialAttributes)
 	// static credentials requires the private key and client email
 	case privateKey != "" && attrs.ClientEmail == "":
 		badFields[fmt.Sprintf("attributes.%s", ConstClientEmail)] = "must not be empty when private key is set"
-	case attrs.ClientEmail != "" && privateKey == "":
-		badFields[fmt.Sprintf("secrets.%s", ConstPrivateKey)] = "must not be empty when client email is set"
 	}
 
 	if len(badFields) > 0 {

--- a/internal/credential/attributes.go
+++ b/internal/credential/attributes.go
@@ -115,13 +115,18 @@ func GetCredentialsConfig(secrets *structpb.Struct, attrs *CredentialAttributes)
 	}
 
 	switch {
-	// dynamic credentials requires the target service account id, cl and private key
-	case attrs.TargetServiceAccountId != "" && (privateKey == "" || attrs.ClientEmail == ""):
+	// service account impersonation authentication requires the target service account id and client_email
+	case attrs.TargetServiceAccountId != "" && attrs.ClientEmail == "":
 		badFields[fmt.Sprintf("secrets.%s", ConstPrivateKey)] = "must not be empty when target service account id is set"
+	// service account impersonation authentication requires the target service account id and private key
+	case attrs.TargetServiceAccountId != "" && privateKey == "":
 		badFields[fmt.Sprintf("attributes.%s", ConstClientEmail)] = "must not be empty when target service account id is set"
-	// static credentials requires the private key and client email
+	// service account key credentials requires the private key and client email
 	case privateKey != "" && attrs.ClientEmail == "":
 		badFields[fmt.Sprintf("attributes.%s", ConstClientEmail)] = "must not be empty when private key is set"
+	// service account key credentials requires the client_email
+	case attrs.ClientEmail != "" && privateKey == "":
+		badFields[fmt.Sprintf("secrets.%s", ConstPrivateKey)] = "must not be empty when client email is set"
 	}
 
 	if len(badFields) > 0 {

--- a/internal/credential/attributes_test.go
+++ b/internal/credential/attributes_test.go
@@ -199,16 +199,6 @@ func TestGetCredentialsConfig(t *testing.T) {
 			expectedErrContains: "must not be empty when private key is set",
 		},
 		{
-			name:    "missing private key with client email",
-			secrets: map[string]any{},
-			attrs: &CredentialAttributes{
-				ClientEmail: "test@test.com",
-				ProjectId:   "test-project",
-				Zone:        "us-central-1a",
-			},
-			expectedErrContains: "must not be empty when client email is set",
-		},
-		{
 			name: "valid static credentials",
 			secrets: map[string]any{
 				ConstPrivateKeyId: "test-private-key-id",

--- a/internal/credential/attributes_test.go
+++ b/internal/credential/attributes_test.go
@@ -199,6 +199,16 @@ func TestGetCredentialsConfig(t *testing.T) {
 			expectedErrContains: "must not be empty when private key is set",
 		},
 		{
+			name:    "missing private key with client email",
+			secrets: map[string]any{},
+			attrs: &CredentialAttributes{
+				ClientEmail: "test@test.com",
+				ProjectId:   "test-project",
+				Zone:        "us-central-1a",
+			},
+			expectedErrContains: "must not be empty when client email is set",
+		},
+		{
 			name: "valid static credentials",
 			secrets: map[string]any{
 				ConstPrivateKeyId: "test-private-key-id",

--- a/internal/credential/rotate.go
+++ b/internal/credential/rotate.go
@@ -24,7 +24,10 @@ const (
 	IAMServiceAccountKeysDeletePermission = "iam.serviceAccountKeys.delete"
 )
 
-type ServiceAccountKey struct {
+// ServiceAccountPrivateKey represents a decoded PrivateKeyData
+// from a Service Account Key.
+// https://cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts.keys#ServiceAccountKey
+type ServiceAccountPrivateKey struct {
 	Type                    string `json:"type"`
 	ProjectID               string `json:"project_id"`
 	PrivateKeyID            string `json:"private_key_id"`
@@ -80,7 +83,7 @@ func (c *Config) RotateServiceAccountKey(ctx context.Context, permissions []stri
 		return status.Errorf(codes.Internal, "error creating service account key: %v", err)
 	}
 
-	var serviceAccountKey ServiceAccountKey
+	var serviceAccountKey ServiceAccountPrivateKey
 	err = json.Unmarshal(createServiceAccountKeyRes.PrivateKeyData, &serviceAccountKey)
 	if err != nil {
 		return status.Errorf(codes.Internal, "error unmarshalling service account key: %v", err)

--- a/internal/credential/rotate.go
+++ b/internal/credential/rotate.go
@@ -5,9 +5,9 @@ package credential
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"slices"
-	"strings"
 
 	admin "cloud.google.com/go/iam/admin/apiv1"
 	"cloud.google.com/go/iam/admin/apiv1/adminpb"
@@ -22,8 +22,20 @@ const (
 	ComputeInstancesListPermission        = "compute.instances.list"
 	IAMServiceAccountKeysCreatePermission = "iam.serviceAccountKeys.create"
 	IAMServiceAccountKeysDeletePermission = "iam.serviceAccountKeys.delete"
-	CreateServiceAccountKeyResourceName   = "projects/-/serviceAccounts"
 )
+
+type ServiceAccountKey struct {
+	Type                    string `json:"type"`
+	ProjectID               string `json:"project_id"`
+	PrivateKeyID            string `json:"private_key_id"`
+	PrivateKey              string `json:"private_key"`
+	ClientEmail             string `json:"client_email"`
+	ClientID                string `json:"client_id"`
+	AuthURI                 string `json:"auth_uri"`
+	TokenURI                string `json:"token_uri"`
+	AuthProviderX509CertURL string `json:"auth_provider_x509_cert_url"`
+	ClientX509CertURL       string `json:"client_x509_cert_url"`
+}
 
 // RotateServiceAccountKey takes the private key from this credentials config
 // and first creates a new private key and private key id, then deletes the
@@ -60,7 +72,7 @@ func (c *Config) RotateServiceAccountKey(ctx context.Context, permissions []stri
 	}
 
 	createServiceAccountKeyRes, err := iamClient.CreateServiceAccountKey(ctx, &adminpb.CreateServiceAccountKeyRequest{
-		Name:           fmt.Sprintf("%s/%s", CreateServiceAccountKeyResourceName, c.ClientEmail),
+		Name:           fmt.Sprintf("projects/%s/serviceAccounts/%s", c.ProjectId, c.ClientEmail),
 		PrivateKeyType: adminpb.ServiceAccountPrivateKeyType_TYPE_GOOGLE_CREDENTIALS_FILE,
 		KeyAlgorithm:   adminpb.ServiceAccountKeyAlgorithm_KEY_ALG_RSA_2048,
 	})
@@ -68,15 +80,16 @@ func (c *Config) RotateServiceAccountKey(ctx context.Context, permissions []stri
 		return status.Errorf(codes.Internal, "error creating service account key: %v", err)
 	}
 
-	privateKeyId, err := getPrivateKeyIdFromName(createServiceAccountKeyRes.Name)
+	var serviceAccountKey ServiceAccountKey
+	err = json.Unmarshal(createServiceAccountKeyRes.PrivateKeyData, &serviceAccountKey)
 	if err != nil {
-		return status.Errorf(codes.Internal, "error parsing private key ID: %v", err)
+		return status.Errorf(codes.Internal, "error unmarshalling service account key: %v", err)
 	}
 
 	// Clone the config, update the private key and private key ID with the new key.
 	newConfig := c.clone()
-	newConfig.PrivateKey = string(createServiceAccountKeyRes.PrivateKeyData)
-	newConfig.PrivateKeyId = privateKeyId
+	newConfig.PrivateKey = serviceAccountKey.PrivateKey
+	newConfig.PrivateKeyId = serviceAccountKey.PrivateKeyID
 
 	newCreds, err := newConfig.GenerateCredentials(ctx)
 	if err != nil {
@@ -100,7 +113,7 @@ func (c *Config) RotateServiceAccountKey(ctx context.Context, permissions []stri
 	}
 
 	err = iamClient.DeleteServiceAccountKey(ctx, &adminpb.DeleteServiceAccountKeyRequest{
-		Name: fmt.Sprintf("%s/%s/keys/%s", CreateServiceAccountKeyResourceName, c.ClientEmail, c.PrivateKeyId),
+		Name: fmt.Sprintf("projects/%s/serviceAccounts/%s/keys/%s", c.ProjectId, c.ClientEmail, c.PrivateKeyId),
 	})
 	if err != nil {
 		return status.Errorf(codes.Internal, "error deleting service account key: %v", err)
@@ -140,7 +153,7 @@ func (c *Config) DeletePrivateKey(ctx context.Context, opts ...option.ClientOpti
 	}
 
 	err = iamClient.DeleteServiceAccountKey(ctx, &adminpb.DeleteServiceAccountKeyRequest{
-		Name: fmt.Sprintf("projects/-/serviceAccounts/%s/keys/%s", c.ClientEmail, c.PrivateKeyId),
+		Name: fmt.Sprintf("projects/%s/serviceAccounts/%s/keys/%s", c.ProjectId, c.ClientEmail, c.PrivateKeyId),
 	})
 	if err != nil {
 		return status.Errorf(codes.Unknown, "error deleting service account key: %v", err)
@@ -196,13 +209,4 @@ func (c *Config) ValidateIamPermissions(ctx context.Context, permissions []strin
 	}
 
 	return resp.Permissions, nil
-}
-
-// getPrivateKeyIdFromName extracts the private key ID from the name of a service account key.
-func getPrivateKeyIdFromName(input string) (string, error) {
-	lastSlashIndex := strings.LastIndex(input, "/")
-	if lastSlashIndex != -1 {
-		return input[lastSlashIndex+1:], nil
-	}
-	return "", fmt.Errorf("could not find private key ID in %s", input)
 }

--- a/internal/credential/testing.go
+++ b/internal/credential/testing.go
@@ -5,6 +5,7 @@ package credential
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 
@@ -29,9 +30,17 @@ func NewTestIAMAdminServer(createServiceAccountKeyError error, deleteServiceAcco
 }
 
 func (f *testIAMAdminServer) CreateServiceAccountKey(ctx context.Context, req *adminpb.CreateServiceAccountKeyRequest) (*adminpb.ServiceAccountKey, error) {
+	serviceAccountKey := ServiceAccountKey{
+		PrivateKey:   "updated-private-key",
+		PrivateKeyID: "updated-private-key-id",
+	}
+	serviceAccountKeyData, err := json.Marshal(serviceAccountKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal service account key: %v", err)
+	}
 	resp := &adminpb.ServiceAccountKey{
 		Name:           "projects/-/serviceAccounts/1234/keys/updated-private-key-id",
-		PrivateKeyData: []byte("updated-private-key"),
+		PrivateKeyData: serviceAccountKeyData,
 	}
 	return resp, f.testCreateServiceAccountKeyError
 }

--- a/internal/credential/testing.go
+++ b/internal/credential/testing.go
@@ -30,7 +30,7 @@ func NewTestIAMAdminServer(createServiceAccountKeyError error, deleteServiceAcco
 }
 
 func (f *testIAMAdminServer) CreateServiceAccountKey(ctx context.Context, req *adminpb.CreateServiceAccountKeyRequest) (*adminpb.ServiceAccountKey, error) {
-	serviceAccountKey := ServiceAccountKey{
+	serviceAccountKey := ServiceAccountPrivateKey{
 		PrivateKey:   "updated-private-key",
 		PrivateKeyID: "updated-private-key-id",
 	}

--- a/plugin/service/host/plugin_test.go
+++ b/plugin/service/host/plugin_test.go
@@ -1199,7 +1199,7 @@ func TestUpdateCatalog(t *testing.T) {
 			expectedErr: "cannot rotate credentials for non-rotatable credentials",
 		},
 		{
-			name: "update target_service_account_id",
+			name: "update application default credentials",
 			req: &pb.OnUpdateCatalogRequest{
 				CurrentCatalog: &hostcatalogs.HostCatalog{
 					Attrs: &hostcatalogs.HostCatalog_Attributes{
@@ -1223,6 +1223,18 @@ func TestUpdateCatalog(t *testing.T) {
 							},
 						},
 					},
+				},
+			},
+			catalogOpts: []gcpCatalogPersistedStateOption{
+				withTestInstancesAPIFunc(newTestMockInstances(ctx,
+					nil,
+					testMockInstancesWithListInstancesOutput(&computepb.InstanceList{}),
+					testMockInstancesWithListInstancesError(nil),
+				)),
+			},
+			expectedRsp: &pb.OnUpdateCatalogResponse{
+				Persisted: &pb.HostCatalogPersisted{
+					Secrets: &structpb.Struct{},
 				},
 			},
 		},

--- a/plugin/service/host/plugin_test.go
+++ b/plugin/service/host/plugin_test.go
@@ -1172,6 +1172,12 @@ func TestUpdateCatalog(t *testing.T) {
 							},
 						},
 					},
+					Secrets: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							cred.ConstPrivateKeyId: structpb.NewStringValue(""),
+							cred.ConstPrivateKey:   structpb.NewStringValue(""),
+						},
+					},
 				},
 				Persisted: &pb.HostCatalogPersisted{
 					Secrets: &structpb.Struct{
@@ -1183,7 +1189,42 @@ func TestUpdateCatalog(t *testing.T) {
 					},
 				},
 			},
+			catalogOpts: []gcpCatalogPersistedStateOption{
+				withTestInstancesAPIFunc(newTestMockInstances(ctx,
+					nil,
+					testMockInstancesWithListInstancesOutput(&computepb.InstanceList{}),
+					testMockInstancesWithListInstancesError(nil),
+				)),
+			},
 			expectedErr: "cannot rotate credentials for non-rotatable credentials",
+		},
+		{
+			name: "update target_service_account_id",
+			req: &pb.OnUpdateCatalogRequest{
+				CurrentCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								cred.ConstProjectId:                 structpb.NewStringValue("test-project"),
+								cred.ConstClientEmail:               structpb.NewStringValue("test@example.com"),
+								cred.ConstZone:                      structpb.NewStringValue("us-central1-a"),
+								cred.ConstDisableCredentialRotation: structpb.NewBoolValue(true),
+							},
+						},
+					},
+				},
+				NewCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								cred.ConstProjectId:                 structpb.NewStringValue("test-project-1"),
+								cred.ConstZone:                      structpb.NewStringValue("us-central1"),
+								cred.ConstDisableCredentialRotation: structpb.NewBoolValue(true),
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
- fix bug where the rotated service account key was not read. The response needs to be unmarshalled to pull out the values from th fields
- fix bug where the timestamp was not getting updated after rotating credentials