### PR TITLE
fix: add status filter when there are no filters

### DIFF
--- a/plugin/service/host/attributes.go
+++ b/plugin/service/host/attributes.go
@@ -108,7 +108,7 @@ func buildListInstancesRequest(attributes *SetAttributes, catalog *CatalogAttrib
 		return nil, fmt.Errorf("error building filters: %w", err)
 	}
 
-	if len(filters) > 1 {
+	if len(filters) > 0 {
 		filters := strings.Join(filters, " AND ")
 		request.Filter = &filters
 	}

--- a/plugin/service/host/attributes_test.go
+++ b/plugin/service/host/attributes_test.go
@@ -183,6 +183,23 @@ func TestBuildListInstancesRequest(t *testing.T) {
 			},
 			expectedErrContains: "error building filters",
 		},
+		{
+			name: "valid request with no filters",
+			attributes: &SetAttributes{
+				Filters: []string{},
+			},
+			catalog: &CatalogAttributes{
+				CredentialAttributes: &cred.CredentialAttributes{
+					ProjectId: "test-12345",
+					Zone:      "us-central-1a",
+				},
+			},
+			expected: &computepb.ListInstancesRequest{
+				Project: "test-12345",
+				Zone:    "us-central-1a",
+				Filter:  stringPtr("status = running"),
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
The if-check `if len(filters) > 1 { ... }` was only assigning filters to the request object when there were 2 or more filters. So, if there were no filters passed in, the default filter wouldn't be assigned to the request object (even though we added it to `filters`)

This also meant that if we tried to filter by status, that wouldn't be respected either because `len(filters) == 1`, and thus the if-check above would skip the line where we assign filters to the request object.