### PR TITLE
fix: remove filter validation when no filters are provided

### DIFF
--- a/plugin/service/host/plugin.go
+++ b/plugin/service/host/plugin.go
@@ -617,11 +617,6 @@ func validateSet(s *hostsets.HostSet) error {
 	}
 
 	badFields := make(map[string]string)
-	_, filterSet := attrMap[ConstListInstancesFilter]
-
-	if filterSet && len(attrs.Filters) == 0 {
-		badFields[fmt.Sprintf("attributes.%s", ConstListInstancesFilter)] = "must not be empty"
-	}
 
 	for f := range attrMap {
 		if _, ok := allowedSetFields[f]; !ok {


### PR DESCRIPTION
the check currently prevents Boundary from unsetting the filter