### PR TITLE
Fix: handle failure of key deletion and rollback

### DIFF
--- a/internal/credential/rotate.go
+++ b/internal/credential/rotate.go
@@ -133,7 +133,7 @@ func (c *Config) RotateServiceAccountKey(
 			Name: fmt.Sprintf("projects/%s/serviceAccounts/%s/keys/%s", newConfig.ProjectId, newConfig.ClientEmail, newConfig.PrivateKeyId),
 		})
 		if rollbackErr != nil {
-			return status.Errorf(codes.PermissionDenied, "error validating rotated service account key: %v; error rolling back newly created service account key: %v; service account may have multiple active keys", err, rollbackErr)
+			return status.Errorf(codes.Internal, "error validating rotated service account key: %v; error rolling back newly created service account key: %v; service account may have multiple active keys", err, rollbackErr)
 		}
 
 		return status.Errorf(codes.PermissionDenied, "error validating rotated service account key: %v; successfully rolled back newly created service account key", err)

--- a/internal/credential/rotate.go
+++ b/internal/credential/rotate.go
@@ -60,6 +60,8 @@ type ValidateCredsCallback func(*Config, ...option.ClientOption) error
 //
 // If deletion of the old private key is successful, the new private key and
 // private key id are written into the credentials config and nil is returned.
+// If validation fails or deleting the old private key fails, the function
+// attempts to delete the newly created key as a rollback operation.
 // On any error, the old credentials are not overwritten.
 func (c *Config) RotateServiceAccountKey(
 	ctx context.Context,
@@ -126,23 +128,30 @@ func (c *Config) RotateServiceAccountKey(
 	// Validate the new service account key
 	err = newConfig.ValidateServiceAccountKey(ctx, permissions, validateCredsCallback, clientOptions...)
 	if err != nil {
-		return status.Errorf(codes.PermissionDenied, "error validating rotated service account key: %v", err)
+		// Roll back the new key if validation fails.
+		rollbackErr := iamClient.DeleteServiceAccountKey(ctx, &adminpb.DeleteServiceAccountKeyRequest{
+			Name: fmt.Sprintf("projects/%s/serviceAccounts/%s/keys/%s", newConfig.ProjectId, newConfig.ClientEmail, newConfig.PrivateKeyId),
+		})
+		if rollbackErr != nil {
+			return status.Errorf(codes.PermissionDenied, "error validating rotated service account key: %v; error rolling back new rotated service account key: %v", err, rollbackErr)
+		}
+
+		return status.Errorf(codes.PermissionDenied, "error validating rotated service account key: %v; successfully rolled back new rotated service account key", err)
 	}
 
-	iamClient, err = admin.NewIamClient(ctx, clientOptions...)
+	newClient, err := admin.NewIamClient(ctx, clientOptions...)
 	if err != nil {
 		return status.Errorf(codes.Internal, "error creating IAM client with rotated service account key: %v", err)
 	}
 
-	oldKeyName := fmt.Sprintf("projects/%s/serviceAccounts/%s/keys/%s", c.ProjectId, c.ClientEmail, c.PrivateKeyId)
-	err = iamClient.DeleteServiceAccountKey(ctx, &adminpb.DeleteServiceAccountKeyRequest{
-		Name: oldKeyName,
+	err = newClient.DeleteServiceAccountKey(ctx, &adminpb.DeleteServiceAccountKeyRequest{
+		Name: fmt.Sprintf("projects/%s/serviceAccounts/%s/keys/%s", c.ProjectId, c.ClientEmail, c.PrivateKeyId),
 	})
 	// If deletion of the old key fails, attempt to delete the new key to avoid leaving a dangling key, then return an error.
 	if err != nil {
-		newKeyName := fmt.Sprintf("projects/%s/serviceAccounts/%s/keys/%s", newConfig.ProjectId, newConfig.ClientEmail, newConfig.PrivateKeyId)
+		// delete the new key using old client since the new client may not have permissions that the old client has.
 		rollbackErr := iamClient.DeleteServiceAccountKey(ctx, &adminpb.DeleteServiceAccountKeyRequest{
-			Name: newKeyName,
+			Name: fmt.Sprintf("projects/%s/serviceAccounts/%s/keys/%s", newConfig.ProjectId, newConfig.ClientEmail, newConfig.PrivateKeyId),
 		})
 		// If rollback also fails, return an error indicating both the failure to delete the old key and the failure to roll back the new key.
 		if rollbackErr != nil {

--- a/internal/credential/rotate.go
+++ b/internal/credential/rotate.go
@@ -134,11 +134,22 @@ func (c *Config) RotateServiceAccountKey(
 		return status.Errorf(codes.Internal, "error creating IAM client with rotated service account key: %v", err)
 	}
 
+	oldKeyName := fmt.Sprintf("projects/%s/serviceAccounts/%s/keys/%s", c.ProjectId, c.ClientEmail, c.PrivateKeyId)
 	err = iamClient.DeleteServiceAccountKey(ctx, &adminpb.DeleteServiceAccountKeyRequest{
-		Name: fmt.Sprintf("projects/%s/serviceAccounts/%s/keys/%s", c.ProjectId, c.ClientEmail, c.PrivateKeyId),
+		Name: oldKeyName,
 	})
+	// If deletion of the old key fails, attempt to delete the new key to avoid leaving a dangling key, then return an error.
 	if err != nil {
-		return status.Errorf(codes.Internal, "error deleting service account key: %v", err)
+		newKeyName := fmt.Sprintf("projects/%s/serviceAccounts/%s/keys/%s", newConfig.ProjectId, newConfig.ClientEmail, newConfig.PrivateKeyId)
+		rollbackErr := iamClient.DeleteServiceAccountKey(ctx, &adminpb.DeleteServiceAccountKeyRequest{
+			Name: newKeyName,
+		})
+		// If rollback also fails, return an error indicating both the failure to delete the old key and the failure to roll back the new key.
+		if rollbackErr != nil {
+			return status.Errorf(codes.Internal, "error deleting service account key: %v; error rolling back new rotated service account key: %v", err, rollbackErr)
+		}
+
+		return status.Errorf(codes.Internal, "error deleting service account key: %v; successfully rolled back new rotated service account key", err)
 	}
 
 	c.PrivateKey = newConfig.PrivateKey

--- a/internal/credential/rotate.go
+++ b/internal/credential/rotate.go
@@ -90,12 +90,12 @@ func (c *Config) RotateServiceAccountKey(
 	clientOptions := []option.ClientOption{option.WithTokenSource(creds.TokenSource)}
 	clientOptions = append(clientOptions, opts...)
 
-	iamClient, err := admin.NewIamClient(ctx, clientOptions...)
+	currentIAMClient, err := admin.NewIamClient(ctx, clientOptions...)
 	if err != nil {
 		return status.Errorf(codes.Internal, "error creating IAM client: %v", err)
 	}
 
-	createServiceAccountKeyRes, err := iamClient.CreateServiceAccountKey(ctx, &adminpb.CreateServiceAccountKeyRequest{
+	createServiceAccountKeyRes, err := currentIAMClient.CreateServiceAccountKey(ctx, &adminpb.CreateServiceAccountKeyRequest{
 		Name:           fmt.Sprintf("projects/%s/serviceAccounts/%s", c.ProjectId, c.ClientEmail),
 		PrivateKeyType: adminpb.ServiceAccountPrivateKeyType_TYPE_GOOGLE_CREDENTIALS_FILE,
 		KeyAlgorithm:   adminpb.ServiceAccountKeyAlgorithm_KEY_ALG_RSA_2048,
@@ -129,33 +129,33 @@ func (c *Config) RotateServiceAccountKey(
 	err = newConfig.ValidateServiceAccountKey(ctx, permissions, validateCredsCallback, clientOptions...)
 	if err != nil {
 		// Roll back the new key if validation fails.
-		rollbackErr := iamClient.DeleteServiceAccountKey(ctx, &adminpb.DeleteServiceAccountKeyRequest{
+		rollbackErr := currentIAMClient.DeleteServiceAccountKey(ctx, &adminpb.DeleteServiceAccountKeyRequest{
 			Name: fmt.Sprintf("projects/%s/serviceAccounts/%s/keys/%s", newConfig.ProjectId, newConfig.ClientEmail, newConfig.PrivateKeyId),
 		})
 		if rollbackErr != nil {
-			return status.Errorf(codes.PermissionDenied, "error validating rotated service account key: %v; error rolling back newly created service account key: %v", err, rollbackErr)
+			return status.Errorf(codes.PermissionDenied, "error validating rotated service account key: %v; error rolling back newly created service account key: %v; service account may have multiple active keys", err, rollbackErr)
 		}
 
 		return status.Errorf(codes.PermissionDenied, "error validating rotated service account key: %v; successfully rolled back newly created service account key", err)
 	}
 
-	newClient, err := admin.NewIamClient(ctx, clientOptions...)
+	newIAMClient, err := admin.NewIamClient(ctx, clientOptions...)
 	if err != nil {
 		return status.Errorf(codes.Internal, "error creating IAM client with rotated service account key: %v", err)
 	}
 
-	err = newClient.DeleteServiceAccountKey(ctx, &adminpb.DeleteServiceAccountKeyRequest{
+	err = newIAMClient.DeleteServiceAccountKey(ctx, &adminpb.DeleteServiceAccountKeyRequest{
 		Name: fmt.Sprintf("projects/%s/serviceAccounts/%s/keys/%s", c.ProjectId, c.ClientEmail, c.PrivateKeyId),
 	})
 	// If deletion of the old key fails, attempt to delete the new key to avoid leaving a dangling key, then return an error.
 	if err != nil {
 		// delete the new key using old client since the new client may not have permissions that the old client has.
-		rollbackErr := iamClient.DeleteServiceAccountKey(ctx, &adminpb.DeleteServiceAccountKeyRequest{
+		rollbackErr := currentIAMClient.DeleteServiceAccountKey(ctx, &adminpb.DeleteServiceAccountKeyRequest{
 			Name: fmt.Sprintf("projects/%s/serviceAccounts/%s/keys/%s", newConfig.ProjectId, newConfig.ClientEmail, newConfig.PrivateKeyId),
 		})
 		// If rollback also fails, return an error indicating both the failure to delete the old key and the failure to roll back the new key.
 		if rollbackErr != nil {
-			return status.Errorf(codes.Internal, "error deleting service account key: %v; error rolling back newly created service account key: %v", err, rollbackErr)
+			return status.Errorf(codes.Internal, "error deleting service account key: %v; error rolling back newly created service account key: %v; service account may have multiple active keys", err, rollbackErr)
 		}
 
 		return status.Errorf(codes.Internal, "error deleting service account key: %v; successfully rolled back newly created service account key", err)

--- a/internal/credential/rotate.go
+++ b/internal/credential/rotate.go
@@ -133,10 +133,10 @@ func (c *Config) RotateServiceAccountKey(
 			Name: fmt.Sprintf("projects/%s/serviceAccounts/%s/keys/%s", newConfig.ProjectId, newConfig.ClientEmail, newConfig.PrivateKeyId),
 		})
 		if rollbackErr != nil {
-			return status.Errorf(codes.PermissionDenied, "error validating rotated service account key: %v; error rolling back new rotated service account key: %v", err, rollbackErr)
+			return status.Errorf(codes.PermissionDenied, "error validating rotated service account key: %v; error rolling back newly created service account key: %v", err, rollbackErr)
 		}
 
-		return status.Errorf(codes.PermissionDenied, "error validating rotated service account key: %v; successfully rolled back new rotated service account key", err)
+		return status.Errorf(codes.PermissionDenied, "error validating rotated service account key: %v; successfully rolled back newly created service account key", err)
 	}
 
 	newClient, err := admin.NewIamClient(ctx, clientOptions...)
@@ -155,10 +155,10 @@ func (c *Config) RotateServiceAccountKey(
 		})
 		// If rollback also fails, return an error indicating both the failure to delete the old key and the failure to roll back the new key.
 		if rollbackErr != nil {
-			return status.Errorf(codes.Internal, "error deleting service account key: %v; error rolling back new rotated service account key: %v", err, rollbackErr)
+			return status.Errorf(codes.Internal, "error deleting service account key: %v; error rolling back newly created service account key: %v", err, rollbackErr)
 		}
 
-		return status.Errorf(codes.Internal, "error deleting service account key: %v; successfully rolled back new rotated service account key", err)
+		return status.Errorf(codes.Internal, "error deleting service account key: %v; successfully rolled back newly created service account key", err)
 	}
 
 	c.PrivateKey = newConfig.PrivateKey

--- a/internal/credential/rotate_test.go
+++ b/internal/credential/rotate_test.go
@@ -72,8 +72,43 @@ func TestRotateServiceAccountKey(t *testing.T) {
 			},
 			setup: func() {
 				testIAMAdminServer.testCreateServiceAccountKeyError = errors.New("create key error")
+				testIAMAdminServer.testDeleteServiceAccountKeyError = nil
+				testIAMAdminServer.testDeleteServiceAccountKeyErrors = nil
+				testResourceServer.testIamPermissionsError = nil
 			},
 			expectedError: errors.New("create key error"),
+		},
+		{
+			name: "ValidateServiceAccountKey fails and rollback succeeds",
+			config: &Config{
+				PrivateKey:                       "some-private-key",
+				PrivateKeyId:                     "some-private-key-id",
+				ClientEmail:                      "client@example.com",
+				validateServiceAccountKeyTimeout: testValidateTimeout,
+			},
+			setup: func() {
+				testIAMAdminServer.testCreateServiceAccountKeyError = nil
+				testIAMAdminServer.testDeleteServiceAccountKeyError = nil
+				testIAMAdminServer.testDeleteServiceAccountKeyErrors = []error{nil}
+				testResourceServer.testIamPermissionsError = errors.New("iam permissions error")
+			},
+			expectedError: errors.New("successfully rolled back new rotated service account key"),
+		},
+		{
+			name: "ValidateServiceAccountKey fails and rollback fails",
+			config: &Config{
+				PrivateKey:                       "some-private-key",
+				PrivateKeyId:                     "some-private-key-id",
+				ClientEmail:                      "client@example.com",
+				validateServiceAccountKeyTimeout: testValidateTimeout,
+			},
+			setup: func() {
+				testIAMAdminServer.testCreateServiceAccountKeyError = nil
+				testIAMAdminServer.testDeleteServiceAccountKeyError = nil
+				testIAMAdminServer.testDeleteServiceAccountKeyErrors = []error{errors.New("rollback key error")}
+				testResourceServer.testIamPermissionsError = errors.New("iam permissions error")
+			},
+			expectedError: errors.New("error rolling back new rotated service account key"),
 		},
 		{
 			name: "DeleteServiceAccountKey old key fails and rollback fails",
@@ -90,6 +125,7 @@ func TestRotateServiceAccountKey(t *testing.T) {
 					errors.New("delete key error"),
 					errors.New("rollback key error"),
 				}
+				testResourceServer.testIamPermissionsError = nil
 			},
 			expectedError: errors.New("error rolling back new rotated service account key"),
 		},
@@ -108,6 +144,7 @@ func TestRotateServiceAccountKey(t *testing.T) {
 					errors.New("delete key error"),
 					nil,
 				}
+				testResourceServer.testIamPermissionsError = nil
 			},
 			expectedError: errors.New("successfully rolled back new rotated service account key"),
 		},
@@ -123,6 +160,7 @@ func TestRotateServiceAccountKey(t *testing.T) {
 				testIAMAdminServer.testCreateServiceAccountKeyError = nil
 				testIAMAdminServer.testDeleteServiceAccountKeyError = nil
 				testIAMAdminServer.testDeleteServiceAccountKeyErrors = nil
+				testResourceServer.testIamPermissionsError = nil
 			},
 			expectedError: nil,
 		},

--- a/internal/credential/rotate_test.go
+++ b/internal/credential/rotate_test.go
@@ -92,7 +92,7 @@ func TestRotateServiceAccountKey(t *testing.T) {
 				testIAMAdminServer.testDeleteServiceAccountKeyErrors = []error{nil}
 				testResourceServer.testIamPermissionsError = errors.New("iam permissions error")
 			},
-			expectedError: errors.New("successfully rolled back new rotated service account key"),
+			expectedError: errors.New("successfully rolled back newly created service account key"),
 		},
 		{
 			name: "ValidateServiceAccountKey fails and rollback fails",
@@ -108,7 +108,7 @@ func TestRotateServiceAccountKey(t *testing.T) {
 				testIAMAdminServer.testDeleteServiceAccountKeyErrors = []error{errors.New("rollback key error")}
 				testResourceServer.testIamPermissionsError = errors.New("iam permissions error")
 			},
-			expectedError: errors.New("error rolling back new rotated service account key"),
+			expectedError: errors.New("error rolling back newly created service account key"),
 		},
 		{
 			name: "DeleteServiceAccountKey old key fails and rollback fails",
@@ -127,7 +127,7 @@ func TestRotateServiceAccountKey(t *testing.T) {
 				}
 				testResourceServer.testIamPermissionsError = nil
 			},
-			expectedError: errors.New("error rolling back new rotated service account key"),
+			expectedError: errors.New("error rolling back newly created service account key"),
 		},
 		{
 			name: "DeleteServiceAccountKey old key fails and rollback succeeds",
@@ -146,7 +146,7 @@ func TestRotateServiceAccountKey(t *testing.T) {
 				}
 				testResourceServer.testIamPermissionsError = nil
 			},
-			expectedError: errors.New("successfully rolled back new rotated service account key"),
+			expectedError: errors.New("successfully rolled back newly created service account key"),
 		},
 		{
 			name: "Successful rotation",

--- a/internal/credential/rotate_test.go
+++ b/internal/credential/rotate_test.go
@@ -76,7 +76,7 @@ func TestRotateServiceAccountKey(t *testing.T) {
 			expectedError: errors.New("create key error"),
 		},
 		{
-			name: "DeleteServiceAccountKey returns error",
+			name: "DeleteServiceAccountKey old key fails and rollback fails",
 			config: &Config{
 				PrivateKey:                       "some-private-key",
 				PrivateKeyId:                     "some-private-key-id",
@@ -85,9 +85,31 @@ func TestRotateServiceAccountKey(t *testing.T) {
 			},
 			setup: func() {
 				testIAMAdminServer.testCreateServiceAccountKeyError = nil
-				testIAMAdminServer.testDeleteServiceAccountKeyError = errors.New("delete key error")
+				testIAMAdminServer.testDeleteServiceAccountKeyError = nil
+				testIAMAdminServer.testDeleteServiceAccountKeyErrors = []error{
+					errors.New("delete key error"),
+					errors.New("rollback key error"),
+				}
 			},
-			expectedError: errors.New("delete key error"),
+			expectedError: errors.New("error rolling back new rotated service account key"),
+		},
+		{
+			name: "DeleteServiceAccountKey old key fails and rollback succeeds",
+			config: &Config{
+				PrivateKey:                       "some-private-key",
+				PrivateKeyId:                     "some-private-key-id",
+				ClientEmail:                      "client@example.com",
+				validateServiceAccountKeyTimeout: testValidateTimeout,
+			},
+			setup: func() {
+				testIAMAdminServer.testCreateServiceAccountKeyError = nil
+				testIAMAdminServer.testDeleteServiceAccountKeyError = nil
+				testIAMAdminServer.testDeleteServiceAccountKeyErrors = []error{
+					errors.New("delete key error"),
+					nil,
+				}
+			},
+			expectedError: errors.New("successfully rolled back new rotated service account key"),
 		},
 		{
 			name: "Successful rotation",
@@ -100,6 +122,7 @@ func TestRotateServiceAccountKey(t *testing.T) {
 			setup: func() {
 				testIAMAdminServer.testCreateServiceAccountKeyError = nil
 				testIAMAdminServer.testDeleteServiceAccountKeyError = nil
+				testIAMAdminServer.testDeleteServiceAccountKeyErrors = nil
 			},
 			expectedError: nil,
 		},

--- a/internal/credential/testing.go
+++ b/internal/credential/testing.go
@@ -18,8 +18,9 @@ import (
 
 type testIAMAdminServer struct {
 	adminpb.UnimplementedIAMServer
-	testCreateServiceAccountKeyError error
-	testDeleteServiceAccountKeyError error
+	testCreateServiceAccountKeyError  error
+	testDeleteServiceAccountKeyError  error
+	testDeleteServiceAccountKeyErrors []error
 }
 
 func NewTestIAMAdminServer(createServiceAccountKeyError error, deleteServiceAccountKeyError error) *testIAMAdminServer {
@@ -46,6 +47,13 @@ func (f *testIAMAdminServer) CreateServiceAccountKey(ctx context.Context, req *a
 }
 
 func (f *testIAMAdminServer) DeleteServiceAccountKey(ctx context.Context, req *adminpb.DeleteServiceAccountKeyRequest) (*emptypb.Empty, error) {
+	// Use queued delete results so tests can separately control deleting the old key and deleting the new key during rollback.
+	if len(f.testDeleteServiceAccountKeyErrors) > 0 {
+		err := f.testDeleteServiceAccountKeyErrors[0]
+		f.testDeleteServiceAccountKeyErrors = f.testDeleteServiceAccountKeyErrors[1:]
+		return &emptypb.Empty{}, err
+	}
+
 	return &emptypb.Empty{}, f.testDeleteServiceAccountKeyError
 }
 


### PR DESCRIPTION
## Description


1.) Updated [rotate.go] so rotation now attempts to delete the newly created key when:
new key validation fails, or old key deletion fails.
2.) Preserved existing safety guarantee: old credentials are not overwritten unless rotation fully succeeds.
3.) Enhanced test mock in [testing.go]  with queued delete outcomes to simulate multi-step delete/rollback flows deterministically.
4.) Extended [rotate_test.go] with validation-failure rollback success/failure cases and kept old-key-delete rollback coverage aligned with current error messages.
5.) JIRA : https://hashicorp.atlassian.net/browse/SECVULN-19519
https://hashicorp.atlassian.net/browse/ICU-18886



## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
